### PR TITLE
Check if there is an internet connection in the splash screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/example/lunark/SplashScreenActivity.java
+++ b/app/src/main/java/com/example/lunark/SplashScreenActivity.java
@@ -1,21 +1,46 @@
 package com.example.lunark;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.provider.Settings;
+import android.widget.Toast;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.example.lunark.tools.CheckConnectionTools;
+import com.google.android.material.snackbar.Snackbar;
 
 import java.util.Timer;
 import java.util.TimerTask;
 
 public class SplashScreenActivity extends Activity {
+    private static final int SPLASH_SCREEN_TIMEOUT = 5000;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.splash_screen);
 
-        int SPLASH_SCREEN_TIMEOUT = 5000;
+        if(!isConnected()) {
+            Toast.makeText(SplashScreenActivity.this, "Not connected to the Internet", Toast.LENGTH_SHORT).show();
+            showConnectionDialog();
+        } else {
+            openLoginScreen();
+        }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if(!isConnected()){
+            Toast.makeText(this, "Failed to connect to the internet", Toast.LENGTH_SHORT).show();
+            this.finish();
+        } else {
+            openLoginScreen();
+        }
+    }
+
+    private void openLoginScreen() {
         new Timer().schedule(new TimerTask() {
             @Override
             public void run() {
@@ -25,6 +50,35 @@ public class SplashScreenActivity extends Activity {
                 finish();
             }
         }, SPLASH_SCREEN_TIMEOUT);
+    }
+
+    public boolean isConnected() {
+        return CheckConnectionTools.getConnectivityStatus(this.getApplicationContext()) != CheckConnectionTools.TYPE_NOT_CONNECTED;
+    }
+
+    private void showConnectionDialog()
+    {
+        int LAUNCH_SECOND_ACTIVITY = 1;
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setMessage("Connect to wifi or mobile data or quit")
+                .setCancelable(false)
+                .setPositiveButton("Connect to WIFI", new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        startActivityForResult(new Intent(Settings.ACTION_WIFI_SETTINGS), LAUNCH_SECOND_ACTIVITY);
+                    }
+                }).setNegativeButton("Connect to mobile data", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        startActivityForResult(new Intent(Settings.ACTION_DATA_ROAMING_SETTINGS), LAUNCH_SECOND_ACTIVITY);
+                    }
+                })
+                .setNeutralButton("Quit", new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        SplashScreenActivity.this.finish();
+                    }
+                });
+        AlertDialog alert = builder.create();
+        alert.show();
     }
 }
 

--- a/app/src/main/java/com/example/lunark/SplashScreenActivity.java
+++ b/app/src/main/java/com/example/lunark/SplashScreenActivity.java
@@ -22,7 +22,7 @@ public class SplashScreenActivity extends Activity {
         setContentView(R.layout.splash_screen);
 
         if(!isConnected()) {
-            Toast.makeText(SplashScreenActivity.this, "Not connected to the Internet", Toast.LENGTH_SHORT).show();
+            Toast.makeText(SplashScreenActivity.this, R.string.not_connected_to_the_internet, Toast.LENGTH_SHORT).show();
             showConnectionDialog();
         } else {
             openLoginScreen();
@@ -33,7 +33,7 @@ public class SplashScreenActivity extends Activity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if(!isConnected()){
-            Toast.makeText(this, "Failed to connect to the internet", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, R.string.failed_to_connect_to_the_internet, Toast.LENGTH_SHORT).show();
             this.finish();
         } else {
             openLoginScreen();
@@ -60,19 +60,19 @@ public class SplashScreenActivity extends Activity {
     {
         int LAUNCH_SECOND_ACTIVITY = 1;
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
-        builder.setMessage("Connect to wifi or mobile data or quit")
+        builder.setMessage(R.string.connect_to_wifi_or_mobile_data_or_quit)
                 .setCancelable(false)
-                .setPositiveButton("Connect to WIFI", new DialogInterface.OnClickListener() {
+                .setPositiveButton(R.string.connect_to_wifi, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         startActivityForResult(new Intent(Settings.ACTION_WIFI_SETTINGS), LAUNCH_SECOND_ACTIVITY);
                     }
-                }).setNegativeButton("Connect to mobile data", new DialogInterface.OnClickListener() {
+                }).setNegativeButton(R.string.connect_to_mobile_data, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         startActivityForResult(new Intent(Settings.ACTION_DATA_ROAMING_SETTINGS), LAUNCH_SECOND_ACTIVITY);
                     }
                 })
-                .setNeutralButton("Quit", new DialogInterface.OnClickListener() {
+                .setNeutralButton(R.string.quit, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         SplashScreenActivity.this.finish();
                     }

--- a/app/src/main/java/com/example/lunark/tools/CheckConnectionTools.java
+++ b/app/src/main/java/com/example/lunark/tools/CheckConnectionTools.java
@@ -1,0 +1,48 @@
+package com.example.lunark.tools;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkCapabilities;
+import android.net.NetworkInfo;
+import android.os.Build;
+import android.util.Log;
+
+public class CheckConnectionTools {
+    public static int TYPE_WIFI = 1;
+    public static int TYPE_MOBILE = 2;
+    public static int TYPE_NOT_CONNECTED = 0;
+
+    public static int getConnectivityStatus(Context context) {
+        ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            //Android is 11(R) or above
+            // https://stackoverflow.com/questions/32547006/connectivitymanager-getnetworkinfoint-deprecated
+            NetworkCapabilities capabilities = cm.getNetworkCapabilities(cm.getActiveNetwork());
+            if (capabilities != null) {
+                if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+                    Log.i("REZ", "Povezan na WIFI");
+                    return TYPE_WIFI;
+                } else if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
+                    Log.i("REZ", "Povezan na celularnu mrezu");
+                    return TYPE_MOBILE;
+                }
+            }
+        }else{
+            // https://developer.android.com/reference/android/net/NetworkInfo
+            //Android is below R
+            NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
+            if (null != activeNetwork) {
+                if (activeNetwork.getType() == ConnectivityManager.TYPE_WIFI)
+                    return TYPE_WIFI;
+
+                if (activeNetwork.getType() == ConnectivityManager.TYPE_MOBILE)
+                    return TYPE_MOBILE;
+            }
+        }
+
+        Log.i("REZ", "Nije povezan na internet");
+        return TYPE_NOT_CONNECTED;
+    }
+
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,12 @@
     <string name="stove">Stove</string>
     <string name="washing_machine">Washing machine</string>
     <string name="amenities">Amenities</string>
+    <string name="not_connected_to_the_internet">Not connected to the Internet</string>
+    <string name="failed_to_connect_to_the_internet">Failed to connect to the internet</string>
+    <string name="connect_to_wifi_or_mobile_data_or_quit">Connect to wifi or mobile data or quit</string>
+    <string name="connect_to_wifi">Connect to WIFI</string>
+    <string name="connect_to_mobile_data">Connect to mobile data</string>
+    <string name="quit">Quit</string>
     <string-array name="property_types_array">
         <item>Apartment</item>
         <item>Cottage</item>


### PR DESCRIPTION
This PR changes the behaviour of the splash screen so that it checks if the device is connected to the internet. If the device is not connected, the app prompts the user to open network settings or quit the app. The app also checks if there is an active internet connection after network settings have been adjusted and quits if there is no internet connection. 