### PR TITLE
Check if JWT has expired on app start

### DIFF
--- a/app/src/main/java/com/example/lunark/LoginScreenActivity.java
+++ b/app/src/main/java/com/example/lunark/LoginScreenActivity.java
@@ -90,7 +90,11 @@ public class LoginScreenActivity extends AppCompatActivity {
 
                     @Override
                     public void onSuccess(Login login) {
-                        openHomeActivity();
+                        if (!login.hasExpired()) {
+                            openHomeActivity();
+                        } else {
+                            loginRepository.clearToken();
+                        }
                     }
 
                     @Override

--- a/app/src/main/java/com/example/lunark/models/Login.java
+++ b/app/src/main/java/com/example/lunark/models/Login.java
@@ -8,6 +8,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.UnsupportedEncodingException;
+import java.time.LocalDate;
+import java.util.Date;
 
 import io.jsonwebtoken.Jwts;
 
@@ -37,6 +39,30 @@ public class Login {
     }
 
     public Long getProfileId() {
+        try {
+            return this.toJson().getLong("profileId");
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getRole() {
+        try {
+            return ((JSONObject)this.toJson().getJSONArray("role").get(0)).getString("authority");
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    public boolean hasExpired() {
+        try {
+            Long expirationTimestamp = this.toJson().getLong("exp");
+            return expirationTimestamp < (new Date().getTime() / 1000);
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private JSONObject toJson() {
         String payload = this.accessToken.split("\\.")[1];
         try {
             payload = new String(Base64.decode(payload, Base64.URL_SAFE), "UTF-8");
@@ -45,7 +71,7 @@ public class Login {
         }
         try {
             JSONObject payloadJson = new JSONObject(payload);
-            return payloadJson.getLong("profileId");
+            return payloadJson;
         } catch (JSONException e) {
             return null;
         }


### PR DESCRIPTION
This PR makes `LoginScreenActivity.trySkipLogin` check if the JWT of the current user has expired.
If the token has expired, the app clears the token from its preferences DataStore, and prompts the user to log in again. 