### PR TITLE
Clear property creation form on wave

### DIFF
--- a/app/src/main/java/com/example/lunark/fragments/createProperty/CreatePropertyFragment.java
+++ b/app/src/main/java/com/example/lunark/fragments/createProperty/CreatePropertyFragment.java
@@ -16,6 +16,7 @@ import androidx.lifecycle.ViewModelProvider;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 
 import com.example.lunark.databinding.FragmentCreatePropertyBinding;
+import com.example.lunark.sensors.ProximitySensorFragment;
 import com.example.lunark.viewmodels.PropertiesViewModel;
 import com.example.lunark.viewmodels.PropertyDetailViewModel;
 import com.stepstone.stepper.Step;
@@ -23,7 +24,7 @@ import com.stepstone.stepper.StepperLayout;
 import com.stepstone.stepper.adapter.AbstractFragmentStepAdapter;
 import com.stepstone.stepper.viewmodel.StepViewModel;
 
-public class CreatePropertyFragment extends Fragment implements IAllowBackPressed {
+public class CreatePropertyFragment extends ProximitySensorFragment implements IAllowBackPressed {
     private final static int NUM_STEPS = 4;
     private FragmentCreatePropertyBinding binding;
     private StepperLayout stepper;
@@ -52,6 +53,15 @@ public class CreatePropertyFragment extends Fragment implements IAllowBackPresse
             return false;
         }
     }
+
+    @Override
+    public void onWave() {
+        Log.d("CREATE_PROPERTY", "GOT WAVE");
+        viewModel.initProperty();
+        stepper.setCurrentStepPosition(0);
+    }
+
+
     private static class MyStepperAdapter extends AbstractFragmentStepAdapter {
 
         public MyStepperAdapter(FragmentManager fm, Context context) {

--- a/app/src/main/java/com/example/lunark/fragments/createProperty/CreatePropertyStep1Fragment.java
+++ b/app/src/main/java/com/example/lunark/fragments/createProperty/CreatePropertyStep1Fragment.java
@@ -216,6 +216,10 @@ public class CreatePropertyStep1Fragment extends Fragment implements Step {
                     binding.sharedRoomRadio.setChecked(true);
                     break;
             }
+        } else {
+            binding.roomRadio.setChecked(false);
+            binding.wholeHouseRadio.setChecked(false);
+            binding.sharedRoomRadio.setChecked(false);
         }
     }
 

--- a/app/src/main/java/com/example/lunark/fragments/createProperty/CreatePropertyStep1Fragment.java
+++ b/app/src/main/java/com/example/lunark/fragments/createProperty/CreatePropertyStep1Fragment.java
@@ -19,6 +19,7 @@ import com.example.lunark.R;
 import com.example.lunark.databinding.FragmentCreatePropertyStep1Binding;
 import com.example.lunark.models.Address;
 import com.example.lunark.models.Property;
+import com.example.lunark.sensors.ProximitySensorFragment;
 import com.example.lunark.viewmodels.PropertyDetailViewModel;
 import com.stepstone.stepper.BlockingStep;
 import com.stepstone.stepper.Step;
@@ -121,6 +122,8 @@ public class CreatePropertyStep1Fragment extends Fragment implements Step {
         binding.minGuestsNumberPicker.setOnValueChangedListener((picker, oldVal, newVal) -> updateViewModel());
         binding.maxGuestsNumberPicker.setOnValueChangedListener((picker, oldVal, newVal) -> updateViewModel());
         binding.addressEditText.addTextChangedListener(textWatcher);
+        binding.cityEditText.addTextChangedListener(textWatcher);
+        binding.countryEditText.addTextChangedListener(textWatcher);
         MapView map = binding.osmmap;
         MapEventsReceiver mapEventsReceiver = new MapEventsReceiver() {
             @Override
@@ -149,6 +152,8 @@ public class CreatePropertyStep1Fragment extends Fragment implements Step {
         binding.minGuestsNumberPicker.setOnValueChangedListener(null);
         binding.maxGuestsNumberPicker.setOnValueChangedListener(null);
         binding.addressEditText.removeTextChangedListener(textWatcher);
+        binding.cityEditText.removeTextChangedListener(textWatcher);
+        binding.countryEditText.removeTextChangedListener(textWatcher);
     }
 
     private void updateViewModel() {
@@ -194,6 +199,8 @@ public class CreatePropertyStep1Fragment extends Fragment implements Step {
             binding.minGuestsNumberPicker.setValue(property.getMinGuests());
             binding.maxGuestsNumberPicker.setValue(property.getMaxGuests());
             binding.addressEditText.setText(property.getAddress().getStreet());
+            binding.cityEditText.setText(property.getAddress().getCity());
+            binding.countryEditText.setText(property.getAddress().getCountry());
             if(property.getType() != null) {
                 restoreLocation(property);
             }

--- a/app/src/main/java/com/example/lunark/fragments/createProperty/CreatePropertyStep1Fragment.java
+++ b/app/src/main/java/com/example/lunark/fragments/createProperty/CreatePropertyStep1Fragment.java
@@ -19,11 +19,8 @@ import com.example.lunark.R;
 import com.example.lunark.databinding.FragmentCreatePropertyStep1Binding;
 import com.example.lunark.models.Address;
 import com.example.lunark.models.Property;
-import com.example.lunark.sensors.ProximitySensorFragment;
 import com.example.lunark.viewmodels.PropertyDetailViewModel;
-import com.stepstone.stepper.BlockingStep;
 import com.stepstone.stepper.Step;
-import com.stepstone.stepper.StepperLayout;
 import com.stepstone.stepper.VerificationError;
 
 import org.osmdroid.api.IMapController;
@@ -201,9 +198,7 @@ public class CreatePropertyStep1Fragment extends Fragment implements Step {
             binding.addressEditText.setText(property.getAddress().getStreet());
             binding.cityEditText.setText(property.getAddress().getCity());
             binding.countryEditText.setText(property.getAddress().getCountry());
-            if(property.getType() != null) {
-                restoreLocation(property);
-            }
+            restoreLocation(property);
             this.updatesEnabled = true;
         });
     }
@@ -225,6 +220,10 @@ public class CreatePropertyStep1Fragment extends Fragment implements Step {
     }
 
     private void restoreLocation(Property property) {
+        this.overlayItems.clear();
+        if (property.getLatitude() == null) {
+            return;
+        }
         setMarker(new GeoPoint(property.getLatitude(), property.getLongitude()));
     }
 
@@ -270,7 +269,6 @@ public class CreatePropertyStep1Fragment extends Fragment implements Step {
     }
 
     private void setMarker(GeoPoint p) {
-        this.overlayItems.clear();
         this.overlayItems.add(new OverlayItem("Your property", "", p));
         this.mapOverlay.setFocusedItem(overlayItems.get(0));
     }

--- a/app/src/main/java/com/example/lunark/fragments/createProperty/CreatePropertyStep2Fragment.java
+++ b/app/src/main/java/com/example/lunark/fragments/createProperty/CreatePropertyStep2Fragment.java
@@ -186,6 +186,7 @@ public class CreatePropertyStep2Fragment extends Fragment implements BlockingSte
             }
             this.updatesEnabled = false;
             this.property = property;
+            amenityCheckboxes.values().forEach(checkBox -> checkBox.setChecked(false));
             for (Amenity amenity: property.getAmenities()) {
                 if (amenityCheckboxes.containsKey(amenity.getName())) {
                     amenityCheckboxes.get(amenity.getName()).setChecked(true);

--- a/app/src/main/java/com/example/lunark/fragments/createProperty/CreatePropertyStep3Fragment.java
+++ b/app/src/main/java/com/example/lunark/fragments/createProperty/CreatePropertyStep3Fragment.java
@@ -219,16 +219,19 @@ public class CreatePropertyStep3Fragment extends Fragment implements Step {
             Log.d("CREATE_PROPERTY", "Reading values from view model");
             this.updatesEnabled = false;
             this.property = property;
+            perPersonRadio.setChecked(false);
+            wholeUnitRadio.setChecked(false);
             if (this.property.getPricingMode().equals("PER_PERSON")) {
                 perPersonRadio.setChecked(true);
             }
             if (this.property.getPricingMode().equals("WHOLE_UNIT")) {
                 wholeUnitRadio.setChecked(true);
             }
-            if (property.getCancellationDeadline() != null){
-                cancellationDeadlineEditText.setText(Integer.toString(property.getCancellationDeadline()));
+            cancellationDeadlineEditText.setText("");
+            if (this.property.getCancellationDeadline() != null) {
+                cancellationDeadlineEditText.setText(this.property.getCancellationDeadline().toString());
             }
-            autoApproveCheckbox.setChecked(property.isAutoApproveEnabled());
+            autoApproveCheckbox.setChecked(this.property.isAutoApproveEnabled());
             this.adapter.setAvailabilityEntries(property.getAvailabilityEntries());
             this.updatesEnabled = true;
         });
@@ -249,6 +252,7 @@ public class CreatePropertyStep3Fragment extends Fragment implements Step {
             int cancellationDeadline = Integer.parseInt(cancellationDeadlineEditText.getText().toString());
             property.setCancellationDeadline(cancellationDeadline);
         } catch (NumberFormatException ex) {
+
         }
         property.setAutoApproveEnabled(autoApproveCheckbox.isChecked());
         viewModel.setProperty(property);

--- a/app/src/main/java/com/example/lunark/models/Property.java
+++ b/app/src/main/java/com/example/lunark/models/Property.java
@@ -12,8 +12,8 @@ public class Property {
     private Address address;
     private int minGuests;
     private int maxGuests;
-    private double latitude;
-    private double longitude;
+    private Double latitude;
+    private Double longitude;
     private List<PropertyImage> images;
     private List<Amenity> amenities;
     private List<AvailabilityEntry> availabilityEntries;
@@ -35,11 +35,11 @@ public class Property {
         availabilityEntries = new ArrayList<>();
         reviews = new ArrayList<>();
         pricingMode = "";
-        address.setCity("N/A");
-        address.setCountry("N/A");
+        latitude = null;
+        longitude = null;
     }
 
-    public Property(Long id, String name, String description, Address address, int minGuests, int maxGuests, double latitude, double longitude, List<PropertyImage> images, List<Amenity> amenities, List<AvailabilityEntry> availabilityEntries, String type, List<Review> reviews, Double averageRating) {
+    public Property(Long id, String name, String description, Address address, int minGuests, int maxGuests, Double latitude, Double longitude, List<PropertyImage> images, List<Amenity> amenities, List<AvailabilityEntry> availabilityEntries, String type, List<Review> reviews, Double averageRating) {
         this.id = id;
         this.name = name;
         this.description = description;
@@ -104,19 +104,19 @@ public class Property {
         this.maxGuests = maxGuests;
     }
 
-    public double getLatitude() {
+    public Double getLatitude() {
         return latitude;
     }
 
-    public void setLatitude(double latitude) {
+    public void setLatitude(Double latitude) {
         this.latitude = latitude;
     }
 
-    public double getLongitude() {
+    public Double getLongitude() {
         return longitude;
     }
 
-    public void setLongitude(double longitude) {
+    public void setLongitude(Double longitude) {
         this.longitude = longitude;
     }
 

--- a/app/src/main/java/com/example/lunark/sensors/ProximitySensorFragment.java
+++ b/app/src/main/java/com/example/lunark/sensors/ProximitySensorFragment.java
@@ -23,7 +23,7 @@ public abstract class ProximitySensorFragment extends Fragment implements Sensor
     private SensorManager sensorManager;
     private Sensor proximitySensor;
 
-    private final int WAVE_TIME = 2000;
+    private final int WAVE_TIME = 3000;
     private final int WAVE_NEEDED_MOVEMENTS = 3;
     private long lastWaveTime = 0;
     private float lastSensorValue;
@@ -54,7 +54,6 @@ public abstract class ProximitySensorFragment extends Fragment implements Sensor
         if (proximitySensor == null) {
             Toast.makeText(requireContext(), "No proximity sensor found in device.", Toast.LENGTH_SHORT).show();
         } else {
-            // registering our sensor with sensor manager
             sensorManager.registerListener(this,
                     proximitySensor,
                     SensorManager.SENSOR_DELAY_NORMAL);

--- a/app/src/main/java/com/example/lunark/sensors/ProximitySensorFragment.java
+++ b/app/src/main/java/com/example/lunark/sensors/ProximitySensorFragment.java
@@ -1,0 +1,113 @@
+package com.example.lunark.sensors;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorEventListener;
+import android.hardware.SensorManager;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import java.util.List;
+
+public abstract class ProximitySensorFragment extends Fragment implements SensorEventListener {
+    private SensorManager sensorManager;
+    private Sensor proximitySensor;
+
+    private final int WAVE_TIME = 2000;
+    private final int WAVE_NEEDED_MOVEMENTS = 3;
+    private long lastWaveTime = 0;
+    private float lastSensorValue;
+    private float maxSensorValue;
+    private float numOfMovements = 0;
+
+
+    public ProximitySensorFragment() {
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        sensorManager = (SensorManager) requireActivity().getSystemService(Context.SENSOR_SERVICE);
+    }
+
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        List<Sensor> sensors = sensorManager.getSensorList(Sensor.TYPE_ALL);
+        for (Sensor s : sensors) {
+            Log.i("REZ_TYPE_ALL", s.getName());
+        }
+
+        proximitySensor = sensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY);
+        if (proximitySensor == null) {
+            Toast.makeText(requireContext(), "No proximity sensor found in device.", Toast.LENGTH_SHORT).show();
+        } else {
+            // registering our sensor with sensor manager
+            sensorManager.registerListener(this,
+                    proximitySensor,
+                    SensorManager.SENSOR_DELAY_NORMAL);
+            maxSensorValue = proximitySensor.getMaximumRange();
+        }
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        sensorManager.unregisterListener(this);
+    }
+
+    @SuppressLint("SetTextI18n")
+    @Override
+    public void onSensorChanged(SensorEvent event) {
+        if (event.sensor.getType() == Sensor.TYPE_PROXIMITY) {
+            if (lastWaveTime + WAVE_TIME < System.currentTimeMillis()) {
+                Log.d("SENSOR", "Reset timing");
+                lastWaveTime = System.currentTimeMillis();
+                numOfMovements = 0;
+                lastSensorValue = event.values[0];
+            } else if (
+                    (event.values[0] != maxSensorValue && lastSensorValue == maxSensorValue) ||
+                    (event.values[0] == maxSensorValue && lastSensorValue != maxSensorValue)) {
+                numOfMovements++;
+                Log.d("SENSOR", "Detected movement");
+                if (numOfMovements == WAVE_NEEDED_MOVEMENTS) {
+                    Log.d("SENSOR", "Wave event");
+                    onWave();
+                    lastWaveTime = System.currentTimeMillis();
+                    numOfMovements = 0;
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onAccuracyChanged(Sensor sensor, int accuracy) {
+        if (sensor.getType() == Sensor.TYPE_ACCELEROMETER) {
+            Log.i("REZ_ACCELEROMETER", String.valueOf(accuracy));
+        } else if (sensor.getType() == Sensor.TYPE_LINEAR_ACCELERATION) {
+            Log.i("REZ_LINEAR_ACCELERATION", String.valueOf(accuracy));
+        } else if (sensor.getType() == Sensor.TYPE_MAGNETIC_FIELD) {
+            Log.i("REZ_MAGNETIC_FIELD", String.valueOf(accuracy));
+        } else if (sensor.getType() == Sensor.TYPE_GYROSCOPE) {
+            Log.i("REZ_GYROSCOPE", String.valueOf(accuracy));
+        } else if (sensor.getType() == Sensor.TYPE_PROXIMITY) {
+            Log.i("REZ_TYPE_PROXIMITY", String.valueOf(accuracy));
+        } else {
+            Log.i("REZ_OTHER_SENSOR", String.valueOf(accuracy));
+        }
+    }
+
+    public abstract void onWave();
+}


### PR DESCRIPTION
This PR adds a feature that lets the user clear the property creation form when they wave over the proximity sensor of the device.